### PR TITLE
build: rework application dockerizing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
-FROM maven:3-jdk-11
-WORKDIR /drone-feeder
-COPY . .
-RUN mvn clean install
-CMD mvn spring-boot:run
+FROM openjdk:11.0-jdk as build-image
+
+WORKDIR /opt/spring_boot
+
+COPY /target/*.jar dronefeeder.jar
+
+SHELL ["/bin/sh", "-c"]
+
+EXPOSE 8080
+
+CMD java -jar dronefeeder.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,36 +1,23 @@
 version: "3.8"
+
 services:
   mysqldb:
     image: mysql:latest
-    restart: unless-stopped
+    restart: always
     env_file: ./.env
     environment:
-      - MYSQL_ROOT_PASSWORD=$MYSQLDB_ROOT_PASSWORD
-      - MYSQL_DATABASE=$MYSQLDB_DATABASE
+     MYSQL_ROOT_PASSWORD: $MYSQLDB_ROOT_PASSWORD
+     MYSQL_DATABASE: $MYSQLDB_DATABASE
     ports:
       - $MYSQLDB_LOCAL_PORT:$MYSQLDB_DOCKER_PORT
     volumes:
       - db:/var/lib/mysql
   app:
-    depends_on:
-      - mysqldb
-    build: .
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
     restart: on-failure
-    env_file: ./.env
     ports:
-      - $SPRING_LOCAL_PORT:$SPRING_DOCKER_PORT
-    environment:
-      SPRING_APPLICATION_JSON: '{
-        "spring.datasource.url"  : "jdbc:mysql://mysqldb:$MYSQLDB_DOCKER_PORT/$MYSQLDB_DATABASE?allowPublicKeyRetrieval=true&useSSL=false",
-        "spring.datasource.username" : "$MYSQLDB_USER",
-        "spring.datasource.password" : "$MYSQLDB_ROOT_PASSWORD",
-        "spring.datasource.driver-class-name" : "com.mysql.cj.jdbc.Driver",
-        "spring.jpa.properties.hibernate.dialect" : "org.hibernate.dialect.MySQL8Dialect",
-        "spring.jpa.hibernate.ddl-auto" : "update"
-        }'
-    volumes:
-      - .m2:/root/.m2
-    stdin_open: true
-    tty: true
+      - 8080:8080
 volumes:
   db:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: P@55w0Rd
+    url: jdbc:mysql://localhost:3306/dronefeeder?useSSL=false&createDatabaseIfNotExist=true
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect


### PR DESCRIPTION
The way docker-compose was previously set, nothing could be done with
the application. Therefore, the application.yml file was remade, taking
that responsibility from the container.